### PR TITLE
(Add) installation script for dnscrypt-proxy for Ubuntu 20.04

### DIFF
--- a/installation/install-dnscrypt-proxy-for-ubuntu-20.04.sh
+++ b/installation/install-dnscrypt-proxy-for-ubuntu-20.04.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sudo apt-get install -y dnscrypt-proxy resolvconf;
+sudo cp /etc/dnscrypt-proxy/dnscrypt-proxy.toml /etc/dnscrypt-proxy/dnscrypt-proxy.toml.original
+NAMESERVER_IP_ADDRESS='127.0.2.1';
+echo 'nameserver '${NAMESERVER_IP_ADDRESS} | sudo tee /etc/resolv.conf.override;
+echo '#!/bin/sh' | sudo tee /etc/NetworkManager/dispatcher.d/20-resolv-conf-override;
+echo 'cp -f /etc/resolv.conf.override /run/resolvconf/resolv.conf;' | sudo tee -a /etc/NetworkManager/dispatcher.d/20-resolv-conf-override;
+sudo chmod +x /etc/NetworkManager/dispatcher.d/20-resolv-conf-override;
+sudo ln -f /etc/NetworkManager/dispatcher.d/20-resolv-conf-override /etc/NetworkManager/dispatcher.d/pre-up.d;
+sudo systemctl restart NetworkManager;
+sudo systemctl restart dnscrypt-proxy;
+
+
+
+


### PR DESCRIPTION
Add installation script for dnscrypt-proxy for Ubuntu 20.04.
Please note that the installed dnscrypt-proxy version is the one that uses systemd sockets to accept connections instead of standard sockets.
I don't want any hassle since I just want it to work, so I go ahead with this change.

Thanks.